### PR TITLE
Removes unnecessary code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const utilShared = require("prettier").util;
 const parse = require("./parser");
 const print = require("./printer");
 
@@ -17,108 +16,23 @@ const languages = [
   }
 ];
 
-function locStart(node) {
-  // This function is copied from the code that used to live in the main prettier repo.
-
-  // Handle nodes with decorators. They should start at the first decorator
-  if (
-    node.declaration &&
-    node.declaration.decorators &&
-    node.declaration.decorators.length > 0
-  ) {
-    return locStart(node.declaration.decorators[0]);
-  }
-  if (node.decorators && node.decorators.length > 0) {
-    return locStart(node.decorators[0]);
-  }
-
-  if (node.__location) {
-    return node.__location.startOffset;
-  }
-  if (node.range) {
-    return node.range[0];
-  }
-  if (typeof node.start === "number") {
-    return node.start;
-  }
-  if (node.source) {
-    return (
-      utilShared.lineColumnToIndex(node.source.start, node.source.input.css) - 1
-    );
-  }
-  if (node.loc) {
-    return node.loc.start;
-  }
-}
-
-function locEnd(node) {
-  // This function is copied from the code that used to live in the main prettier repo.
-
-  const endNode = node.nodes && utilShared.getLast(node.nodes);
-  if (endNode && node.source && !node.source.end) {
-    node = endNode;
-  }
-
-  let loc;
-  if (node.range) {
-    loc = node.range[1];
-  } else if (typeof node.end === "number") {
-    loc = node.end;
-  } else if (node.source) {
-    loc = utilShared.lineColumnToIndex(node.source.end, node.source.input.css);
-  }
-
-  if (node.__location) {
-    return node.__location.endOffset;
-  }
-  if (node.typeAnnotation) {
-    return Math.max(loc, locEnd(node.typeAnnotation));
-  }
-
-  if (node.loc && !loc) {
-    return node.loc.end;
-  }
-
-  return loc;
-}
-
 const parsers = {
   elm: {
     parse,
     astFormat: "elm-format",
-    locStart: locStart,
-    locEnd: locEnd
+    // there's only a single node
+    locStart(node) {
+      return node.start;
+    },
+    locEnd(node) {
+      return node.end;
+    }
   }
 };
 
-const options = {};
-
-function canAttachComment(node) {
-  return node.ast_type && node.ast_type !== "comment";
-}
-
-function printComment(commentPath) {
-  const comment = commentPath.getValue();
-
-  switch (comment.ast_type) {
-    case "comment":
-      return comment.value;
-    default:
-      throw new Error("Not a comment: " + JSON.stringify(comment));
-  }
-}
-
-function clean(ast, newObj) {
-  delete newObj.lineno;
-  delete newObj.col_offset;
-}
-
 const printers = {
   "elm-format": {
-    print,
-    printComment,
-    canAttachComment,
-    massageAstNode: clean
+    print
   }
 };
 
@@ -126,6 +40,5 @@ module.exports = {
   languages,
   printers,
   parsers,
-  options,
   defaultOptions: {}
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -13,18 +13,18 @@ function formatTextWithElmFormat(text) {
 
 /*
  * Simply passing text to elm-format is not enough because of two problems:
- *  
+ *
  * 1. If the code chunk contains no symbol assignments, elm-format fails.
  * 2. `module Main exposing (..)` is always added if no module has been defined,
  *    which is not wanted in markdown code blocks.
- * 
+ *
  * Both problems are related to https://github.com/avh4/elm-format/issues/65.
  * Until this upstream issue is fixed, two custom patches are applied:
- * 
+ *
  * 1. A temporary dummy statement is appended to text before sending it to elm-format.
  * 2. If elm-format's result defines a module while the source does not,
  *    module definition is trimmed while working with a markdown code block.
- * 
+ *
  * Please submit an issue to https://github.com/gicentre/prettier-plugin-elm/issues
  * if there are any problems caused by the patches.
  */
@@ -62,8 +62,7 @@ function parse(text, parsers, opts) {
   return {
     ast_type: "elm-format",
     body: formattedText,
-    comments: [],
-    end: text.length,
+    end: text.legth,
     source: text,
     start: 0
   };


### PR DESCRIPTION
After you've mentioned you copy-pasted code I came here and noticed this code isn't necessary at all. You only have a single type of node (`elm-format`) which you make it yourself so there's no need for this code.

Also, since you're not handling comments at all, it's better if `node.comments` is `undefined` which makes prettier skip the comment handling (so you don't need it the other methods as well).