### PR TITLE
Implement caching mechanism to speed-up formatting of Elm blocks in markdown files

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,7 +14,7 @@ rules:
   curly: error
   import/no-extraneous-dependencies:
   - error
-  - devDependencies: ["tests*/**", "scripts/**"]
+  - devDependencies: ["test/**"]
   no-else-return: error
   no-inner-declarations: error
   no-unneeded-ternary: error

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 *.log
 /.vscode
 .DS_Store
+cache
 coverage
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "6"
   - "8"
   - "9"
+  - "10"
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,7 @@ notifications:
   email:
     on_success: never
     on_failure: change
+
+branches:
+  only:
+    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: "{build}"
+skip_tags: true
+build: off
+clone_depth: 1
+shallow_clone: true
+matrix:
+  fast_finish: true
+
+environment:
+  ELM_VERSION: "0.18.0"
+  matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "9"
+    - nodejs_version: "10"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:Platform
+  - node --version
+  - yarn --version
+  - npm install --global elm@%ELM_VERSION%
+  - set CI=true
+  - yarn
+
+test_script:
+  - yarn test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,7 @@ install:
 
 test_script:
   - yarn test
+
+branches:
+  only:
+    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ install:
   - ps: Install-Product node $env:nodejs_version $env:Platform
   - node --version
   - yarn --version
-  - npm install --global elm@%ELM_VERSION%
   - set CI=true
   - yarn
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "prettier-plugin"
   ],
   "scripts": {
+    "clean:coverage": "rimraf coverage",
+    "clean:test": "rimraf cache",
     "lint": "jest -c jest.eslint.config.js && prettier-check {*,src/**/*,test/*}.{md,js}",
     "test": "jest -c jest.test.config.js --no-coverage",
     "test:coverage": "jest -c jest.test.config.js",
@@ -31,11 +33,17 @@
     "jest": "^22.4.3",
     "jest-runner-eslint": "^0.4.0",
     "prettier": "^1.12.0",
-    "prettier-check": "^2.0.0"
+    "prettier-check": "^2.0.0",
+    "rimraf": "^2.6.2",
+    "sleep-promise": "^6.0.0"
   },
   "dependencies": {
     "elm-format": "0.7.0-exp",
-    "execa": "^0.10.0"
+    "execa": "^0.10.0",
+    "make-dir": "^1.3.0",
+    "object-hash": "^1.3.0",
+    "serialize-error": "^2.1.0",
+    "temp-dir": "^1.0.0"
   },
   "peerDependencies": {
     "prettier": "^1.11.0"

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const fs = require("fs");
+const makeDir = require("make-dir");
+const objectHash = require("object-hash");
+const path = require("path");
+const serializeError = require("serialize-error");
+const tempDir = require("temp-dir");
+
+const cacheDir = process.env.PRETTIER_PLUGIN_ELM_CACHE_DIR
+  ? path.resolve(process.env.PRETTIER_PLUGIN_ELM_CACHE_DIR)
+  : path.resolve(tempDir, "prettier-plugin-elm");
+
+const cacheMax = process.env.PRETTIER_PLUGIN_ELM_CACHE_MAX
+  ? parseInt(process.env.PRETTIER_PLUGIN_ELM_CACHE_MAX, 10)
+  : 1000;
+
+const cacheGCInterval = process.env.PRETTIER_PLUGIN_ELM_CACHE_GC_INTERVAL
+  ? parseInt(process.env.PRETTIER_PLUGIN_ELM_CACHE_GC_INTERVAL, 10)
+  : 1000 * 60;
+
+/* istanbul ignore next */
+const noop = () => {};
+
+function getCachedValue(fn, args) {
+  const cacheKey = objectHash(args);
+  const recordFilePath = path.resolve(cacheDir, `${cacheKey}.json`);
+  let record;
+  let recordIsFromCache = false;
+
+  // load value or error from cache
+  try {
+    record = JSON.parse(fs.readFileSync(recordFilePath, "utf8"));
+    recordIsFromCache = true;
+  } catch (e) {
+    // a failure to load from cache implies calling fn
+    try {
+      record = {
+        value: fn.apply(null, args)
+      };
+    } catch (fnError) {
+      const serializedError = serializeError(fnError);
+      delete serializedError.stack;
+      record = {
+        error: serializedError
+      };
+    }
+  }
+
+  try {
+    makeDir.sync(cacheDir);
+    fs.writeFileSync(`${recordFilePath}.touchfile`, "");
+    if (!recordIsFromCache) {
+      fs.writeFileSync(recordFilePath, JSON.stringify(record), "utf8");
+    }
+    collectGarbageIfNeeded();
+  } catch (e) {
+    // a failure to save record into cache or clean garbage
+    // should not affect the result of the function
+
+    /* istanbul ignore next */
+    if (process.env.NODE_ENV === "test") {
+      throw e;
+    }
+  }
+
+  if (record.error) {
+    const errorToThrow = new Error();
+    for (const errorProperty in record.error) {
+      /* istanbul ignore else */
+      if (record.error.hasOwnProperty(errorProperty)) {
+        errorToThrow[errorProperty] = record.error.property;
+      }
+    }
+    throw errorToThrow;
+  } else {
+    return record.value;
+  }
+}
+
+function collectGarbageIfNeeded() {
+  const pathToGCTouchfile = path.resolve(cacheDir, `gc.touchfile`);
+  try {
+    const lastGCTime = fs.statSync(pathToGCTouchfile).mtimeMs;
+    if (lastGCTime + cacheGCInterval > +new Date()) {
+      // no need to collect garbage
+      return;
+    }
+  } catch (e) {
+    // a failure to read modification time for the GC touchfile
+    // means that GC needs to be done for the first time
+  }
+
+  fs.writeFileSync(pathToGCTouchfile, "");
+  const recordInfos = [];
+  fs.readdirSync(cacheDir).map(recordFileName => {
+    if (!recordFileName.endsWith(".json")) {
+      return;
+    }
+    const recordFilePath = path.resolve(cacheDir, recordFileName);
+    const recordInfo = {
+      path: recordFilePath,
+      touchedAt: 0
+    };
+    try {
+      recordInfo.touchedAt = fs.statSync(`${recordFilePath}.touchfile`).mtimeMs;
+    } catch (e) {
+      // fs.statSync may fail if another GC process has just deleted it;
+      // this is not critical
+
+      /* istanbul ignore next */
+      if (process.env.NODE_ENV === "test") {
+        throw e;
+      }
+    }
+    recordInfos.push(recordInfo);
+  });
+
+  recordInfos.sort((a, b) => {
+    return b.touchedAt - a.touchedAt;
+  });
+  const recordInfosToDelete = recordInfos.slice(cacheMax);
+
+  recordInfosToDelete.forEach(recordInfo => {
+    // files are deleted asynchronously and possible errors are ignored
+    fs.unlink(recordInfo.path, noop);
+    fs.unlink(`${recordInfo.path}.touchfile`, noop);
+  });
+}
+
+module.exports = {
+  getCachedValue
+};

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,15 +1,8 @@
 "use strict";
 
-const execa = require("execa");
-
-function formatTextWithElmFormat(text) {
-  return execa.sync("elm-format", ["--stdin"], {
-    input: text,
-    preferLocal: true,
-    localDir: __dirname,
-    stripEof: false
-  });
-}
+const pkg = require("../package.json");
+const { getCachedValue } = require("./cache");
+const { formatTextWithElmFormat } = require("./util");
 
 /*
  * Simply passing text to elm-format is not enough because of two problems:
@@ -38,8 +31,10 @@ function parse(text, parsers, opts) {
   const textToSend = `${text}${dummyStatement}`;
 
   // extract formatted text from elm-format
-  const executionResult = formatTextWithElmFormat(textToSend);
-  let formattedText = executionResult.stdout.toString();
+  let formattedText = getCachedValue(formatTextWithElmFormat, [
+    textToSend,
+    pkg.version
+  ]);
 
   // path 1 (step 2/2)
   formattedText = formattedText.replace(dummyStatementRegExp, "\n");
@@ -62,7 +57,7 @@ function parse(text, parsers, opts) {
   return {
     ast_type: "elm-format",
     body: formattedText,
-    end: text.legth,
+    end: text.length,
     source: text,
     start: 0
   };

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const execa = require("execa");
+
+function formatTextWithElmFormat(text) {
+  return execa.sync("elm-format", ["--stdin"], {
+    input: text,
+    preferLocal: true,
+    localDir: __dirname,
+    stripEof: false
+  }).stdout;
+}
+
+module.exports = {
+  formatTextWithElmFormat
+};

--- a/test/caching.test.js
+++ b/test/caching.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const prettier = require("prettier");
+const rimraf = require("rimraf");
+const sleep = require("sleep-promise");
+
+const util = require("../src/util");
+
+const fixturesDirName = path.resolve(__dirname, "fixtures");
+const cacheDir = path.resolve(__dirname, "../cache");
+const cacheMax = 21; // number of blocks in multiple-blocks.md fixture
+const cacheGCInterval = 1000;
+
+test(`correctly deals with cache`, () => {
+  rimraf.sync(cacheDir);
+  process.env.PRETTIER_PLUGIN_ELM_CACHE_DIR = cacheDir;
+  process.env.PRETTIER_PLUGIN_ELM_CACHE_MAX = `${cacheMax}`;
+  process.env.PRETTIER_PLUGIN_ELM_CACHE_GC_INTERVAL = `${cacheGCInterval}`;
+
+  const spyForFormatTextWithElmFormat = jest.spyOn(
+    util,
+    "formatTextWithElmFormat"
+  );
+
+  const sourceText = fs.readFileSync(
+    path.resolve(fixturesDirName, "multiple-blocks.md"),
+    "utf8"
+  );
+  const expectedFormattedText = fs.readFileSync(
+    path.resolve(fixturesDirName, "multiple-blocks.prettified.md"),
+    "utf8"
+  );
+
+  // multiple-blocks.md, first run – no cache
+  expect(
+    prettier.format(sourceText, {
+      parser: "markdown",
+      plugins: [path.resolve(__dirname, "..")]
+    })
+  ).toEqual(expectedFormattedText);
+  const numberOfFormatCallsInFirstRun =
+    spyForFormatTextWithElmFormat.mock.calls.length;
+  expect(numberOfFormatCallsInFirstRun).toBeGreaterThan(0);
+
+  // multiple-blocks.md, second run – with cache
+  expect(
+    prettier.format(sourceText, {
+      parser: "markdown",
+      plugins: [path.resolve(__dirname, "..")]
+    })
+  ).toEqual(expectedFormattedText);
+  expect(spyForFormatTextWithElmFormat.mock.calls).toHaveLength(
+    numberOfFormatCallsInFirstRun
+  );
+
+  return sleep(cacheGCInterval * 2).then(() => {
+    // a call to formatTextWithElmFormat() that triggers garbage collection
+    prettier.format("", {
+      parser: "elm",
+      plugins: [path.resolve(__dirname, "..")]
+    });
+
+    // multiple-blocks.md, third run – with cache except for one block that was previously garbage collected
+    expect(
+      prettier.format(sourceText, {
+        parser: "markdown",
+        plugins: [path.resolve(__dirname, "..")]
+      })
+    ).toEqual(expectedFormattedText);
+    expect(spyForFormatTextWithElmFormat.mock.calls).toHaveLength(
+      numberOfFormatCallsInFirstRun + 1 /* for "" */ + 1 /* for GC-d block */
+    );
+  });
+});

--- a/test/fixtures/multiple-blocks.md
+++ b/test/fixtures/multiple-blocks.md
@@ -1,0 +1,727 @@
+---
+id: "litvis"
+elm:
+    dependencies:
+        gicentre/elm-vega: latest
+---
+
+<!-- source (with minor amendments): https://github.com/gicentre/litvis/blob/master/documents/tutorials/geoTutorials/geoFormats.md -->
+
+@import "../css/tutorial.less"
+
+```elm {l=hidden}
+import VegaLite exposing (..)
+```
+
+_This is one of a series of 'geo' tutorials for use with litvis._
+
+1.  **Geospatial File Formats**
+2.  [Generating Global Map Projection Geo Files](geoGenerating.md)
+3.  [Importing geographic datasets into elm-vega](geoImporting.md)
+
+---
+
+# Geospatial File Formats
+
+Geospatial features can be represented either with conventional (x,y) coordinates or with 'speherical' longitude, latitude angles.
+While the planar (x,y) coordinate system is simpler and probably more familiar, it provides a poor representation of larger regions of the earth where its spheroidal shape cannot be accurately represented as a flat surface.
+This tutorial considers the [geoJson](http://geojson.org) and [topoJson](https://github.com/topojson/topojson/wiki) file formats that can be used for more faithful representation of geographic data.
+
+## 1. Planar and Spherical Coordinates
+
+Let's first consider how we might represent a broadly rectangular region with simple (x,y) coordinates.
+
+```elm {l}
+myRegion : List DataColumn -> Data
+myRegion =
+    dataFromColumns []
+        <<    dataColumn "order" (nums [ 1, 2, 3, 4, 5 ])
+        <<    dataColumn "easting" (nums [ -3, 4, 4, -3, -3 ])
+        <<    dataColumn "northing" (nums [ 52, 52, 45, 45, 52 ])
+```
+
+Note that we need to provide an `order` field to define the order in which the coordinates representing each point of the boundary are to be linked with a line mark.
+Note also that while the region has only 4 corners, we provide 5 sets of coordinate pairs, the last one matching the first one to _close_ the shape.
+
+With the boundary region defined we can encode it as a `line` mark using the `X` and `Y` `position` channels:
+
+```elm {l v s}
+planar : Spec
+planar =
+    let
+        enc =
+            encoding
+                << position X [ pName "easting", pMType Quantitative, pScale [ scZero False ] ]
+                << position Y [ pName "northing", pMType Quantitative, pScale [ scZero False ] ]
+                << order [ oName "order", oMType Ordinal ]
+    in
+    toVegaLite [ myRegion [], enc [], line [] ]
+```
+
+But if those `easting` and `northing` values represent longitude and latitude, have we produced a sufficiently accurate two-dimensional visual representation of what is a three-dimensional portion of the earth's surface?
+
+Here's the representation assuming spherical coordinates, noting that we are now encoding the position coordinates with `Longitude` and `Latitude` types rather than the Cartesian `X` and `Y` types.
+
+```elm {v l s}
+geo : Spec
+geo =
+    let
+        proj =
+            projection [ prType Orthographic ]
+
+        enc =
+            encoding
+                << position Longitude [ pName "easting", pMType Quantitative ]
+                << position Latitude [ pName "northing", pMType Quantitative ]
+                << order [ oName "order", oMType Ordinal ]
+    in
+    toVegaLite [ width 250, height 250, myRegion [], proj, enc [], line [] ]
+```
+
+The `Orthographic` map projection used above gives a more accurate indication of the east-west distances of region's corners, here demonstrating the northern boundary is shorter than the southern one.
+Viewing it in a global context makes it clearer why this is the case:
+
+```elm {v l=hidden}
+globe : Spec
+globe =
+    let
+        pDetails =
+            [ width 250, height 250, projection [ prType Orthographic, prRotate 0 -15 0 ] ]
+
+        graticuleSpec =
+            asSpec
+                (pDetails
+                    ++ [ dataFromUrl (path "graticule.json") [ topojsonMesh "graticule" ]
+                       , geoshape [ maStroke "black", maFilled False, maStrokeWidth 0.1 ]
+                       ]
+                )
+
+        countrySpec =
+            asSpec
+                (pDetails
+                    ++ [ dataFromUrl (path "world-110m.json") [ topojsonFeature "countries1" ]
+                       , geoshape [ maStroke "white", maFill "black", maStrokeWidth 0.1, maFillOpacity 0.1 ]
+                       ]
+                )
+
+        circleSpec =
+            asSpec
+                (pDetails
+                    ++ [ dataFromUrl (path "topoJson1.json") [ topojsonMesh "myRegion" ]
+                       , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.3 ]
+                       ]
+                )
+    in
+    toVegaLite
+        [ configure (configuration (coView [ vicoStroke Nothing ]) [])
+        , layer [ graticuleSpec, countrySpec, circleSpec ]
+        ]
+```
+
+We have established that there can be good reason to represent geographic regions with spherical coordinates.
+But how do we represent boundaries more complex than simple squares?
+This is where the 'geoJSON' and 'topoJSON' file formats are useful.
+
+## 2. Simple Geometry Files
+
+Let's first consider the [geoJson](http://geojson.org) file format which is commonly used for representing geo data.
+The simple rectangle above can be represented by the following geoJSON file:
+
+```Javascript
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+    ]
+  }
+}
+```
+
+Again, we see the 5 coordinate pairs representing the points along the region's boundary including a duplicated first and last point to close the region.
+GeoJSON files can represent a range of geometry types such as individual points, lines, complex polygons with holes and islands as well as collections of these features.
+But for the moment let's just stick with the simple polygon.
+
+To display the file, simply load it as any normal data file and encode it with the `geoshape` function.
+
+To keep things flexible, we'll define a `path` function in Elm pointing to the base directory where all data are stored.
+You can leave the default as shown below to load the data from the giCentre data repository or replace it with a local folder if you have your own copy of the data.
+
+```elm {l}
+path : String -> String
+path fileName =
+    "https://gicentre.github.io/data/geoTutorials/" ++ fileName
+```
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "geoJson1.json") []
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+Notice that not only is the `geoshape` a more concise specification than the region boundary as a `line`, but also the bounding lines themselves are not straight, more accurately reflecting the projection from the sphere onto the plane.
+
+As we shall see, larger geo data are more efficiently stored not as geoJSON, but as [topoJson](https://github.com/topojson/topojson/wiki) files.
+These store the same geometric information as their geoJSON counterparts but addtionally represent the _topology_ of the features.
+Here is the equivalent topoJSON file representing the geoJSON above:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegion": {
+      "type": "Polygon",
+      "arcs": [ [0] ]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+  ]
+}
+```
+
+Similarly, we can display this file directly in elm-vega with `geoshape`.
+Because topojson files can contain many `objects`, we have to specify which object we are loading (in this case `myRegion`).
+Objects themselves can be treated either as _meshes_ or _features_.
+A `topojsonMesh` treats the entire object as a single entity and is quicker to render.
+On the other hand a `topojsonFeature` allows individual features within the object to be handled separately.
+In this simple example, we can store the object as a `topojsonMesh`:
+
+```elm {s l}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson1.json") [ topojsonMesh "myRegion" ]
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+But why do we use a topoJSON file rather than what looks like a simpler geoJSON file?
+The answer is clearer if we consider a file representing two adjacent regions:
+
+```elm {s v l=hidden}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson2.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+Here is its geoJSON representation:
+
+```Javascript
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 59], [4, 59], [4, 52], [-3, 52], [-3, 59] ]
+        ]
+      }
+    }
+  ]
+}
+```
+
+This file contains not one but two `Polygon` features.
+Both are nested within an outer `features` array which in this case contains two elements, but could contain many more.
+Notice how the common edge between these two adjacent regions is duplicated (the boundary between (-3,52) and (4,52)).
+In this case that duplication isn't a big problem, but imagine that boundary was a complex meandering line with many hundreds of coordinate pairs.
+
+The topoJSON format instead stores all boundaries as distinct _arcs_ that are then resassembled to form area boundaries.
+If more than one feature shares a common arc, it is only stored once:
+
+```javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1] ]
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 2] ]
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ]
+  ]
+}
+```
+
+The arcs are referenced by their array position (0, 1 and 2 in this example) to form the two polygons.
+
+_Why do you think arc 1 is referenced by `-1` rather than `1` for the second polygon?
+Try drawing out the vertices, boundary lines and regions if you are not sure._
+
+## 3. Feature IDs
+
+So far we have only considered the geometry of features.
+Each feature can addtionally have an `id` that stores some property to be associated with the feature, for example a country name, or population count.
+
+Keeping with our simple two-region example, let's attach a text `id` with each of the features (in the objects placed in the `geometries` array):
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1] ],
+        "id" : "southern region"
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 2] ],
+        "id" : "northern region"
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ]
+  ]
+}
+```
+
+We can now encode the `id` in its visualization specification:
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson3.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "id", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+## 4. Feature Properties
+
+The `id` is a useful and concise way of identifying a single property in a topoJSON file, but only one `id` is permitted for each feature.
+TopoJSON and GeoJSON files that need to store multiple attributes for each feature may store `properties` objects that can have any number of json objects associated with them.
+Here is an example of our two-region topoJSON file where each feature contains no `id` but instead the properties `myRegionName` and `myPopulationCount`:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "properties": {
+            "myRegionName": "southern region",
+            "myPopulationCount": 27000,
+          },
+        "arcs": [ [0, 1] ]
+      }, {
+        "type": "Polygon",
+        "properties": {
+            "myRegionName": "northern region",
+            "myPopulationCount": 18000,
+          },
+        "arcs": [ [-1, 2] ]
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ]
+  ]
+}
+```
+
+We can access any of the properties by using dot notation to identify nested json elements.
+For example to access `myRegionName` for each feature we would use `properties.myRegionName` in its specification instead of `id`.
+Below we access all instances of the `myPopulationCount` property to colour each feature:
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson4.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myPopulationCount", mMType Quantitative ] [])
+        , geoshape []
+        ]
+```
+
+## 5. Complex Geometry
+
+So far the features we have considered have been 'simple polygons', i.e. each polygon is defined by a single ring of coordinates.
+Features can be more complex than this though, for example, a single feature might be made up of a collection of simple polygons in a geoJSON file:
+
+```Javascript
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+        ]
+      },
+      "properties": {"myRegionName": "southern region"}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 59], [ 4, 59], [ 4, 52], [-3, 52], [-3, 59] ],
+          [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+        ]
+      },
+      "properties": {"myRegionName": "northern region"}
+    }
+  ]
+}
+```
+
+Notice that the coordinates array for the northern region now contains two elements, each of which is a ring of 5 coordinate pairs.
+Its equivalent topoJSON file looks like this:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1] ],
+        "properties": { "myRegionName": "southern region" }
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 2], [3] ],
+        "properties": { "myRegionName": "northern region" }
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [ 4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ],
+    [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+  ]
+}
+```
+
+We can display topojson in much the same way as for the simple polygons:
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson5.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myRegionName", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+Finally, it is possible to have 'holes' within polygons and even 'islands' within those holes in cases where one polygon ring is within another.
+Here is the geoJSON that defines two further rings within the southern region.
+Note that in order to specify a hole, the order of coordinates is anti-clockwise whereas the outer ring and inner island, bounding 'positive' areas are in clockwise order.
+
+```Javascript
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 52], [ 4, 52], [4, 45], [-3, 45], [-3, 52] ],
+          [ [-1, 50], [-1, 47], [2, 47], [ 2, 50], [-1, 50] ],
+          [ [ 0, 49], [ 1, 49], [1, 48], [ 0, 48], [ 0, 49] ]
+        ]
+      },
+      "properties": {"myRegionName": "southern region"}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 59], [ 4, 59], [ 4, 52], [-3, 52], [-3, 59] ],
+          [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+        ]
+      },
+      "properties": {"myRegionName": "northern region"}
+    }
+  ]
+}
+```
+
+The topojson equivalent is much as we have seen before, but now incorporating the two extra rings:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1], [2], [3] ],
+        "properties": { "myRegionName": "southern region" }
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 4], [5]],
+        "properties": { "myRegionName": "northern region" }
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [ 4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-1, 50], [-1, 47], [ 2, 47], [ 2, 50], [-1, 50] ],
+    [ [ 0, 49], [ 1, 49], [ 1, 48], [ 0, 48], [ 0, 49] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ],
+    [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+  ]
+}
+```
+
+```elm {s v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson6.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myRegionName", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+## 6. Creating JSON files programatically
+
+In all the examples above the topoJSON and geoJSON has been read from external files.
+This is likely the most common use-case, but sometimes it can be useful to generate the content programmtically.
+This can be achieved using elm-vega's [dataFromJson](http://package.elm-lang.org/packages/gicentre/elm-vega/latest/VegaLite#dataFromJson) and supplying it with a `geometry` function.
+Here, for example, is a simple rectangular feature (equivalent to `geoJson1.json` above) generated programmatically:
+
+```elm {s l}
+geo : Spec
+geo =
+    let
+        geojson =
+            geometry (geoPolygon [ [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 52 ), ( -3, 59 ) ] ]) []
+    in
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromJson geojson []
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+More complex features can be built up by assembling `geometry` specs as a `geoFeatureCollection`:
+
+```elm {s l v}
+geo : Spec
+geo =
+    let
+        geojson =
+            geoFeatureCollection
+                [ geometry (geoPoint 5 55) []
+                , geometry
+                    (geoPolygons
+                        [ [ [ ( -3, 52 ), ( 4, 52 ), ( 4, 45 ), ( -3, 45 ), ( -3, 52 ) ]
+                          , [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 52 ), ( -3, 59 ) ]
+                          ]
+                        , [ [ ( -7, 58 ), ( -5, 58 ), ( -5, 56 ), ( -7, 56 ), ( -7, 58 ) ] ]
+                        ]
+                    )
+                    []
+                ]
+    in
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromJson geojson []
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+Feature properties can be added to the last parameter of each `geometry` call and are expressed as a list of key, value pairs in the same way as they are when calling `dataRow`.
+For example:
+
+```elm {s l v}
+geo : Spec
+geo =
+    let
+        geojson =
+            geoFeatureCollection
+                [ geometry (geoPolygon [ [ ( -3, 52 ), ( 4, 52 ), ( 4, 45 ), ( -3, 45 ), ( -3, 52 ) ] ]) [ ( "myRegionName", str "Southern region" ) ]
+                , geometry (geoPolygon [ [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 52 ), ( -3, 59 ) ] ]) [ ( "myRegionName", str "Northern region" ) ]
+                ]
+    in
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromJson geojson [ jsonProperty "features" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myRegionName", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+### Programatically Generated Graticule
+
+Generating geo data programmatically allows us to create features that contain regular structures quite easily.
+The following creates a graticule (lines of longitude and latitude):
+
+```elm {l}
+range : Float -> Float -> Float -> List Float
+range mn mx step =
+    List.range 0 ((mx - mn) / step |> round) |> List.map (\x -> mn + (toFloat x * step))
+
+
+graticule : Float -> Geometry
+graticule gStep =
+    let
+        meridian lng =
+            if round lng % 90 == 0 then
+                List.map (\lat -> ( lng, lat )) (range -90 90 (min 10 gStep))
+            else
+                List.map (\lat -> ( lng, lat )) (range (gStep - 90) (90 - gStep) (min 5 gStep))
+
+        parallel : Float -> List ( Float, Float )
+        parallel lat =
+            List.map (\lng -> ( lng, lat )) (range -180 180 (min 10 gStep))
+    in
+    geoLines (List.map parallel (range (gStep - 90) (90 - gStep) gStep) ++ List.map meridian (range -180 180 gStep))
+```
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ configure (configuration (coView [ vicoStroke Nothing ]) [])
+        , width 200
+        , height 200
+        , dataFromJson (geometry (graticule 10) []) []
+        , projection [ prType Orthographic, prRotate 5 -30 0 ]
+        , geoshape [ maStrokeWidth 0.2, maFilled False ]
+        ]
+```
+
+### Programatically Generated Tissot's Indicatrices
+
+We can add a grid of small circles to simulate _Tissot's Indicatrices_ for showing local map projection distortion properties:
+
+```elm {l}
+tissot : Float -> Geometry
+tissot gStep =
+    let
+        degToRad15 x =
+            15 * degToRad (toFloat x)
+
+        degToRad x =
+            x * pi / 180
+
+        radToDeg x =
+            x * 180 / pi
+
+        rnd x =
+            (x * 10 |> round |> toFloat) / 10
+
+        circle cLng cLat r =
+            let
+                circ i =
+                    let
+                        lat =
+                            cLat + radToDeg (degToRad r * cos (degToRad15 i))
+                    in
+                    ( rnd <| cLng + radToDeg (degToRad r / cos (degToRad lat) * sin (degToRad15 i)), rnd lat )
+            in
+            List.map circ (List.range 0 24)
+
+        circles lng =
+            List.map (\i -> circle lng i 5) (range -80 80 20)
+    in
+    geoPolygons <| List.map (\lng -> circles lng) (range -180 160 30)
+```
+
+```elm {s l v}
+geo : Spec
+geo =
+    let
+        proj =
+            projection [ prType Orthographic, prRotate 45 -30 0 ]
+
+        specGraticule =
+            asSpec
+                [ dataFromJson (geometry (graticule 10) []) []
+                , proj
+                , geoshape [ maStrokeWidth 0.2, maFilled False ]
+                ]
+
+        specTissot =
+            asSpec
+                [ dataFromJson (geometry (tissot 30) []) []
+                , proj
+                , geoshape [ maStroke "#00a2f3", maStrokeWidth 0.5, maFill "#00a2f3", maFillOpacity 0.1 ]
+                ]
+    in
+    toVegaLite
+        [ configure (configuration (coView [ vicoStroke Nothing ]) [])
+        ,   width 400
+        ,   height 400
+        ,   layer [ specGraticule, specTissot ]
+        ]
+```
+
+```elm
+geo : Spec
+geo =
+    broken; elm code
+```

--- a/test/fixtures/multiple-blocks.prettified.md
+++ b/test/fixtures/multiple-blocks.prettified.md
@@ -1,0 +1,727 @@
+---
+id: "litvis"
+elm:
+    dependencies:
+        gicentre/elm-vega: latest
+---
+
+<!-- source (with minor amendments): https://github.com/gicentre/litvis/blob/master/documents/tutorials/geoTutorials/geoFormats.md -->
+
+@import "../css/tutorial.less"
+
+```elm {l=hidden}
+import VegaLite exposing (..)
+```
+
+_This is one of a series of 'geo' tutorials for use with litvis._
+
+1.  **Geospatial File Formats**
+2.  [Generating Global Map Projection Geo Files](geoGenerating.md)
+3.  [Importing geographic datasets into elm-vega](geoImporting.md)
+
+---
+
+# Geospatial File Formats
+
+Geospatial features can be represented either with conventional (x,y) coordinates or with 'speherical' longitude, latitude angles.
+While the planar (x,y) coordinate system is simpler and probably more familiar, it provides a poor representation of larger regions of the earth where its spheroidal shape cannot be accurately represented as a flat surface.
+This tutorial considers the [geoJson](http://geojson.org) and [topoJson](https://github.com/topojson/topojson/wiki) file formats that can be used for more faithful representation of geographic data.
+
+## 1. Planar and Spherical Coordinates
+
+Let's first consider how we might represent a broadly rectangular region with simple (x,y) coordinates.
+
+```elm {l}
+myRegion : List DataColumn -> Data
+myRegion =
+    dataFromColumns []
+        << dataColumn "order" (nums [ 1, 2, 3, 4, 5 ])
+        << dataColumn "easting" (nums [ -3, 4, 4, -3, -3 ])
+        << dataColumn "northing" (nums [ 52, 52, 45, 45, 52 ])
+```
+
+Note that we need to provide an `order` field to define the order in which the coordinates representing each point of the boundary are to be linked with a line mark.
+Note also that while the region has only 4 corners, we provide 5 sets of coordinate pairs, the last one matching the first one to _close_ the shape.
+
+With the boundary region defined we can encode it as a `line` mark using the `X` and `Y` `position` channels:
+
+```elm {l v s}
+planar : Spec
+planar =
+    let
+        enc =
+            encoding
+                << position X [ pName "easting", pMType Quantitative, pScale [ scZero False ] ]
+                << position Y [ pName "northing", pMType Quantitative, pScale [ scZero False ] ]
+                << order [ oName "order", oMType Ordinal ]
+    in
+    toVegaLite [ myRegion [], enc [], line [] ]
+```
+
+But if those `easting` and `northing` values represent longitude and latitude, have we produced a sufficiently accurate two-dimensional visual representation of what is a three-dimensional portion of the earth's surface?
+
+Here's the representation assuming spherical coordinates, noting that we are now encoding the position coordinates with `Longitude` and `Latitude` types rather than the Cartesian `X` and `Y` types.
+
+```elm {v l s}
+geo : Spec
+geo =
+    let
+        proj =
+            projection [ prType Orthographic ]
+
+        enc =
+            encoding
+                << position Longitude [ pName "easting", pMType Quantitative ]
+                << position Latitude [ pName "northing", pMType Quantitative ]
+                << order [ oName "order", oMType Ordinal ]
+    in
+    toVegaLite [ width 250, height 250, myRegion [], proj, enc [], line [] ]
+```
+
+The `Orthographic` map projection used above gives a more accurate indication of the east-west distances of region's corners, here demonstrating the northern boundary is shorter than the southern one.
+Viewing it in a global context makes it clearer why this is the case:
+
+```elm {v l=hidden}
+globe : Spec
+globe =
+    let
+        pDetails =
+            [ width 250, height 250, projection [ prType Orthographic, prRotate 0 -15 0 ] ]
+
+        graticuleSpec =
+            asSpec
+                (pDetails
+                    ++ [ dataFromUrl (path "graticule.json") [ topojsonMesh "graticule" ]
+                       , geoshape [ maStroke "black", maFilled False, maStrokeWidth 0.1 ]
+                       ]
+                )
+
+        countrySpec =
+            asSpec
+                (pDetails
+                    ++ [ dataFromUrl (path "world-110m.json") [ topojsonFeature "countries1" ]
+                       , geoshape [ maStroke "white", maFill "black", maStrokeWidth 0.1, maFillOpacity 0.1 ]
+                       ]
+                )
+
+        circleSpec =
+            asSpec
+                (pDetails
+                    ++ [ dataFromUrl (path "topoJson1.json") [ topojsonMesh "myRegion" ]
+                       , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.3 ]
+                       ]
+                )
+    in
+    toVegaLite
+        [ configure (configuration (coView [ vicoStroke Nothing ]) [])
+        , layer [ graticuleSpec, countrySpec, circleSpec ]
+        ]
+```
+
+We have established that there can be good reason to represent geographic regions with spherical coordinates.
+But how do we represent boundaries more complex than simple squares?
+This is where the 'geoJSON' and 'topoJSON' file formats are useful.
+
+## 2. Simple Geometry Files
+
+Let's first consider the [geoJson](http://geojson.org) file format which is commonly used for representing geo data.
+The simple rectangle above can be represented by the following geoJSON file:
+
+```Javascript
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+    ]
+  }
+}
+```
+
+Again, we see the 5 coordinate pairs representing the points along the region's boundary including a duplicated first and last point to close the region.
+GeoJSON files can represent a range of geometry types such as individual points, lines, complex polygons with holes and islands as well as collections of these features.
+But for the moment let's just stick with the simple polygon.
+
+To display the file, simply load it as any normal data file and encode it with the `geoshape` function.
+
+To keep things flexible, we'll define a `path` function in Elm pointing to the base directory where all data are stored.
+You can leave the default as shown below to load the data from the giCentre data repository or replace it with a local folder if you have your own copy of the data.
+
+```elm {l}
+path : String -> String
+path fileName =
+    "https://gicentre.github.io/data/geoTutorials/" ++ fileName
+```
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "geoJson1.json") []
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+Notice that not only is the `geoshape` a more concise specification than the region boundary as a `line`, but also the bounding lines themselves are not straight, more accurately reflecting the projection from the sphere onto the plane.
+
+As we shall see, larger geo data are more efficiently stored not as geoJSON, but as [topoJson](https://github.com/topojson/topojson/wiki) files.
+These store the same geometric information as their geoJSON counterparts but addtionally represent the _topology_ of the features.
+Here is the equivalent topoJSON file representing the geoJSON above:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegion": {
+      "type": "Polygon",
+      "arcs": [ [0] ]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+  ]
+}
+```
+
+Similarly, we can display this file directly in elm-vega with `geoshape`.
+Because topojson files can contain many `objects`, we have to specify which object we are loading (in this case `myRegion`).
+Objects themselves can be treated either as _meshes_ or _features_.
+A `topojsonMesh` treats the entire object as a single entity and is quicker to render.
+On the other hand a `topojsonFeature` allows individual features within the object to be handled separately.
+In this simple example, we can store the object as a `topojsonMesh`:
+
+```elm {s l}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson1.json") [ topojsonMesh "myRegion" ]
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+But why do we use a topoJSON file rather than what looks like a simpler geoJSON file?
+The answer is clearer if we consider a file representing two adjacent regions:
+
+```elm {s v l=hidden}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson2.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+Here is its geoJSON representation:
+
+```Javascript
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 59], [4, 59], [4, 52], [-3, 52], [-3, 59] ]
+        ]
+      }
+    }
+  ]
+}
+```
+
+This file contains not one but two `Polygon` features.
+Both are nested within an outer `features` array which in this case contains two elements, but could contain many more.
+Notice how the common edge between these two adjacent regions is duplicated (the boundary between (-3,52) and (4,52)).
+In this case that duplication isn't a big problem, but imagine that boundary was a complex meandering line with many hundreds of coordinate pairs.
+
+The topoJSON format instead stores all boundaries as distinct _arcs_ that are then resassembled to form area boundaries.
+If more than one feature shares a common arc, it is only stored once:
+
+```javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1] ]
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 2] ]
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ]
+  ]
+}
+```
+
+The arcs are referenced by their array position (0, 1 and 2 in this example) to form the two polygons.
+
+_Why do you think arc 1 is referenced by `-1` rather than `1` for the second polygon?
+Try drawing out the vertices, boundary lines and regions if you are not sure._
+
+## 3. Feature IDs
+
+So far we have only considered the geometry of features.
+Each feature can addtionally have an `id` that stores some property to be associated with the feature, for example a country name, or population count.
+
+Keeping with our simple two-region example, let's attach a text `id` with each of the features (in the objects placed in the `geometries` array):
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1] ],
+        "id" : "southern region"
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 2] ],
+        "id" : "northern region"
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ]
+  ]
+}
+```
+
+We can now encode the `id` in its visualization specification:
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson3.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "id", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+## 4. Feature Properties
+
+The `id` is a useful and concise way of identifying a single property in a topoJSON file, but only one `id` is permitted for each feature.
+TopoJSON and GeoJSON files that need to store multiple attributes for each feature may store `properties` objects that can have any number of json objects associated with them.
+Here is an example of our two-region topoJSON file where each feature contains no `id` but instead the properties `myRegionName` and `myPopulationCount`:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "properties": {
+            "myRegionName": "southern region",
+            "myPopulationCount": 27000,
+          },
+        "arcs": [ [0, 1] ]
+      }, {
+        "type": "Polygon",
+        "properties": {
+            "myRegionName": "northern region",
+            "myPopulationCount": 18000,
+          },
+        "arcs": [ [-1, 2] ]
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ]
+  ]
+}
+```
+
+We can access any of the properties by using dot notation to identify nested json elements.
+For example to access `myRegionName` for each feature we would use `properties.myRegionName` in its specification instead of `id`.
+Below we access all instances of the `myPopulationCount` property to colour each feature:
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson4.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myPopulationCount", mMType Quantitative ] [])
+        , geoshape []
+        ]
+```
+
+## 5. Complex Geometry
+
+So far the features we have considered have been 'simple polygons', i.e. each polygon is defined by a single ring of coordinates.
+Features can be more complex than this though, for example, a single feature might be made up of a collection of simple polygons in a geoJSON file:
+
+```Javascript
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 52], [4, 52], [4, 45], [-3, 45], [-3, 52] ]
+        ]
+      },
+      "properties": {"myRegionName": "southern region"}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 59], [ 4, 59], [ 4, 52], [-3, 52], [-3, 59] ],
+          [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+        ]
+      },
+      "properties": {"myRegionName": "northern region"}
+    }
+  ]
+}
+```
+
+Notice that the coordinates array for the northern region now contains two elements, each of which is a ring of 5 coordinate pairs.
+Its equivalent topoJSON file looks like this:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1] ],
+        "properties": { "myRegionName": "southern region" }
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 2], [3] ],
+        "properties": { "myRegionName": "northern region" }
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [ 4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ],
+    [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+  ]
+}
+```
+
+We can display topojson in much the same way as for the simple polygons:
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson5.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myRegionName", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+Finally, it is possible to have 'holes' within polygons and even 'islands' within those holes in cases where one polygon ring is within another.
+Here is the geoJSON that defines two further rings within the southern region.
+Note that in order to specify a hole, the order of coordinates is anti-clockwise whereas the outer ring and inner island, bounding 'positive' areas are in clockwise order.
+
+```Javascript
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 52], [ 4, 52], [4, 45], [-3, 45], [-3, 52] ],
+          [ [-1, 50], [-1, 47], [2, 47], [ 2, 50], [-1, 50] ],
+          [ [ 0, 49], [ 1, 49], [1, 48], [ 0, 48], [ 0, 49] ]
+        ]
+      },
+      "properties": {"myRegionName": "southern region"}
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [ [-3, 59], [ 4, 59], [ 4, 52], [-3, 52], [-3, 59] ],
+          [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+        ]
+      },
+      "properties": {"myRegionName": "northern region"}
+    }
+  ]
+}
+```
+
+The topojson equivalent is much as we have seen before, but now incorporating the two extra rings:
+
+```Javascript
+{
+  "type": "topology",
+  "objects": {
+    "myRegions": {
+      "type": "GeometryCollection",
+      "geometries": [{
+        "type": "Polygon",
+        "arcs": [ [0, 1], [2], [3] ],
+        "properties": { "myRegionName": "southern region" }
+      }, {
+        "type": "Polygon",
+        "arcs": [ [-1, 4], [5]],
+        "properties": { "myRegionName": "northern region" }
+      }]
+    }
+  },
+  "arcs": [
+    [ [-3, 52], [ 4, 52] ],
+    [ [ 4, 52], [ 4, 45], [-3, 45], [-3, 52] ],
+    [ [-1, 50], [-1, 47], [ 2, 47], [ 2, 50], [-1, 50] ],
+    [ [ 0, 49], [ 1, 49], [ 1, 48], [ 0, 48], [ 0, 49] ],
+    [ [-3, 52], [-3, 59], [ 4, 59], [ 4, 52] ],
+    [ [-6, 58], [-4, 58], [-4, 56], [-6, 56], [-6, 58] ]
+  ]
+}
+```
+
+```elm {s v}
+geo : Spec
+geo =
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromUrl (path "topoJson6.json") [ topojsonFeature "myRegions" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myRegionName", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+## 6. Creating JSON files programatically
+
+In all the examples above the topoJSON and geoJSON has been read from external files.
+This is likely the most common use-case, but sometimes it can be useful to generate the content programmtically.
+This can be achieved using elm-vega's [dataFromJson](http://package.elm-lang.org/packages/gicentre/elm-vega/latest/VegaLite#dataFromJson) and supplying it with a `geometry` function.
+Here, for example, is a simple rectangular feature (equivalent to `geoJson1.json` above) generated programmatically:
+
+```elm {s l}
+geo : Spec
+geo =
+    let
+        geojson =
+            geometry (geoPolygon [ [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 52 ), ( -3, 59 ) ] ]) []
+    in
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromJson geojson []
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+More complex features can be built up by assembling `geometry` specs as a `geoFeatureCollection`:
+
+```elm {s l v}
+geo : Spec
+geo =
+    let
+        geojson =
+            geoFeatureCollection
+                [ geometry (geoPoint 5 55) []
+                , geometry
+                    (geoPolygons
+                        [ [ [ ( -3, 52 ), ( 4, 52 ), ( 4, 45 ), ( -3, 45 ), ( -3, 52 ) ]
+                          , [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 52 ), ( -3, 59 ) ]
+                          ]
+                        , [ [ ( -7, 58 ), ( -5, 58 ), ( -5, 56 ), ( -7, 56 ), ( -7, 58 ) ] ]
+                        ]
+                    )
+                    []
+                ]
+    in
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromJson geojson []
+        , projection [ prType Orthographic ]
+        , geoshape [ maStroke "#00a2f3", maFill "#00a2f3", maFillOpacity 0.5 ]
+        ]
+```
+
+Feature properties can be added to the last parameter of each `geometry` call and are expressed as a list of key, value pairs in the same way as they are when calling `dataRow`.
+For example:
+
+```elm {s l v}
+geo : Spec
+geo =
+    let
+        geojson =
+            geoFeatureCollection
+                [ geometry (geoPolygon [ [ ( -3, 52 ), ( 4, 52 ), ( 4, 45 ), ( -3, 45 ), ( -3, 52 ) ] ]) [ ( "myRegionName", str "Southern region" ) ]
+                , geometry (geoPolygon [ [ ( -3, 59 ), ( 4, 59 ), ( 4, 52 ), ( -3, 52 ), ( -3, 59 ) ] ]) [ ( "myRegionName", str "Northern region" ) ]
+                ]
+    in
+    toVegaLite
+        [ width 200
+        , height 200
+        , dataFromJson geojson [ jsonProperty "features" ]
+        , projection [ prType Orthographic ]
+        , encoding (color [ mName "properties.myRegionName", mMType Nominal ] [])
+        , geoshape []
+        ]
+```
+
+### Programatically Generated Graticule
+
+Generating geo data programmatically allows us to create features that contain regular structures quite easily.
+The following creates a graticule (lines of longitude and latitude):
+
+```elm {l}
+range : Float -> Float -> Float -> List Float
+range mn mx step =
+    List.range 0 ((mx - mn) / step |> round) |> List.map (\x -> mn + (toFloat x * step))
+
+
+graticule : Float -> Geometry
+graticule gStep =
+    let
+        meridian lng =
+            if round lng % 90 == 0 then
+                List.map (\lat -> ( lng, lat )) (range -90 90 (min 10 gStep))
+            else
+                List.map (\lat -> ( lng, lat )) (range (gStep - 90) (90 - gStep) (min 5 gStep))
+
+        parallel : Float -> List ( Float, Float )
+        parallel lat =
+            List.map (\lng -> ( lng, lat )) (range -180 180 (min 10 gStep))
+    in
+    geoLines (List.map parallel (range (gStep - 90) (90 - gStep) gStep) ++ List.map meridian (range -180 180 gStep))
+```
+
+```elm {s l v}
+geo : Spec
+geo =
+    toVegaLite
+        [ configure (configuration (coView [ vicoStroke Nothing ]) [])
+        , width 200
+        , height 200
+        , dataFromJson (geometry (graticule 10) []) []
+        , projection [ prType Orthographic, prRotate 5 -30 0 ]
+        , geoshape [ maStrokeWidth 0.2, maFilled False ]
+        ]
+```
+
+### Programatically Generated Tissot's Indicatrices
+
+We can add a grid of small circles to simulate _Tissot's Indicatrices_ for showing local map projection distortion properties:
+
+```elm {l}
+tissot : Float -> Geometry
+tissot gStep =
+    let
+        degToRad15 x =
+            15 * degToRad (toFloat x)
+
+        degToRad x =
+            x * pi / 180
+
+        radToDeg x =
+            x * 180 / pi
+
+        rnd x =
+            (x * 10 |> round |> toFloat) / 10
+
+        circle cLng cLat r =
+            let
+                circ i =
+                    let
+                        lat =
+                            cLat + radToDeg (degToRad r * cos (degToRad15 i))
+                    in
+                    ( rnd <| cLng + radToDeg (degToRad r / cos (degToRad lat) * sin (degToRad15 i)), rnd lat )
+            in
+            List.map circ (List.range 0 24)
+
+        circles lng =
+            List.map (\i -> circle lng i 5) (range -80 80 20)
+    in
+    geoPolygons <| List.map (\lng -> circles lng) (range -180 160 30)
+```
+
+```elm {s l v}
+geo : Spec
+geo =
+    let
+        proj =
+            projection [ prType Orthographic, prRotate 45 -30 0 ]
+
+        specGraticule =
+            asSpec
+                [ dataFromJson (geometry (graticule 10) []) []
+                , proj
+                , geoshape [ maStrokeWidth 0.2, maFilled False ]
+                ]
+
+        specTissot =
+            asSpec
+                [ dataFromJson (geometry (tissot 30) []) []
+                , proj
+                , geoshape [ maStroke "#00a2f3", maStrokeWidth 0.5, maFill "#00a2f3", maFillOpacity 0.1 ]
+                ]
+    in
+    toVegaLite
+        [ configure (configuration (coView [ vicoStroke Nothing ]) [])
+        , width 400
+        , height 400
+        , layer [ specGraticule, specTissot ]
+        ]
+```
+
+```elm
+geo : Spec
+geo =
+    broken; elm code
+```

--- a/test/format-fixtures.test.js
+++ b/test/format-fixtures.test.js
@@ -3,9 +3,16 @@
 const fs = require("fs");
 const path = require("path");
 const prettier = require("prettier");
+const tempDir = require("temp-dir");
+const rimraf = require("rimraf");
 
 const fixturesDirName = path.resolve(__dirname, "fixtures");
 const files = fs.readdirSync(fixturesDirName);
+
+beforeAll(() => {
+  rimraf.sync(path.resolve(tempDir, "prettier-plugin-elm"));
+});
+
 files.forEach(sourceFileName => {
   if (
     !sourceFileName.match(/\.(md|elm)$/) ||
@@ -14,7 +21,7 @@ files.forEach(sourceFileName => {
     return;
   }
 
-  test(`${sourceFileName}`, () => {
+  test(`formats fixture ${sourceFileName}`, () => {
     const formattedFileName = sourceFileName.replace(
       /(\.[a-z]+)$/,
       ".prettified$1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2436,6 +2436,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+make-dir@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  dependencies:
+    pify "^3.0.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -2687,6 +2693,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
+
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
@@ -2871,7 +2881,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@3.0.0:
+pify@3.0.0, pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
@@ -3236,7 +3246,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -3294,6 +3304,10 @@ sax@^1.2.4:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
+serialize-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3341,6 +3355,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+sleep-promise@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sleep-promise/-/sleep-promise-6.0.0.tgz#a80b4c3c26ed553c73c9db7234bc0304f7d42d4a"
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -3611,6 +3629,10 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
 
 test-exclude@^4.2.1:
   version "4.2.1"


### PR DESCRIPTION
Prettier parsers and printers work synchronously until https://github.com/prettier/prettier/issues/4459 is discussed and resolved. This means that formatting a markdown file with a large number of Elm blocks takes a while, because for each block a new `elm-format` is spawned in a sequence.

This PR introduces a simple [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) caching mechanism that works on top of the filesystem. The cache speeds-up consequent formatting of the same text, even between independent prettier executions. Occasionally, garbage collection is invoked to protect cache directory from growing indefinitely.

Each new version of `prettier-plugin-elm` will use its own cached results, because the value of the version from `package.json` is mixed with the text to format when generating cache key.

By default, the cache is stored in `$TMPDIR/prettier-plugin-elm`, but this location can be changed with the environment variable. In practice, this is only needed during testing, so caching can be considered as zero-config.

Caching can be extracted into a separate NPM module as it's pretty generic and I'm happy to do so if someone is interested in reusing it (just ping me).