### PR TITLE
Set minimum Node version to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "typescript": "^4.3.5",
     "yarn-deduplicate": "^3.1.0"
   },
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "run-if-changed": {
     "yarn.lock": "yarn install --prefer-offline --pure-lockfile"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "inlineSourceMap": true,
-    "lib": ["es2016"],
-    "moduleResolution": "node",
+    "lib": ["ES2019"],
+    "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true
+    "strict": true,
+    "target": "ES2019"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Node 10 reached end of life in April 2021. See https://nodejs.org/en/about/releases/