### PR TITLE
Add `execa` timeout

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,7 @@ export const getElmFormatVersion = () => {
     const help = execa.sync("elm-format", ["--help"], {
       preferLocal: true,
       localDir: __dirname,
+      timeout: 5000,
     }).stdout;
     const helpMatch = help.match(/elm-format ([^\n]+)/);
     cachedElmFormatVersion = helpMatch ? helpMatch[1] : "unknown";
@@ -24,5 +25,6 @@ export const formatTextWithElmFormat = (text: string): string => {
     preferLocal: true,
     localDir: __dirname,
     stripFinalNewline: false,
+    timeout: 15_000,
   }).stdout;
 };


### PR DESCRIPTION
If `elm-format` binary fails to install, calls to `execa` end up unterminated. Adding timeout prevents plugin from hanging forever.

This edge case has been spotted in CI recently and should be quite rare.