### PR TITLE
Update production dependencies, stop supporting Node.js below v18

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,6 @@ module.exports = {
 
   rules: {
     "unicorn/prefer-module": "off", // Can be enabled after switching to ESM
-    "unicorn/prefer-node-protocol": "off", // Can be enabled after switching to ESM or dropping Node.js 14
   },
 
   settings: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26, windows-2025, ubuntu-24.04]
-        node: [20, 22, 24]
+        node: [18, 20, 22, 24]
         exclude:
           - os: ubuntu-22.04
             node: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26, windows-2025, ubuntu-24.04]
-        node: [18, 22, 24]
+        node: [20, 22, 24]
         exclude:
           - os: ubuntu-22.04
             node: 24

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "dependencies": {
+    "cross-spawn": "7.0.6",
     "elm-format": "0.8.8",
     "object-hash": "^3.0.0",
     "serialize-error": "^12.0.0",
@@ -53,6 +54,7 @@
     "@kachkaev/markdownlint-config": "0.5.0",
     "@tsconfig/recommended": "1.0.10",
     "@tsconfig/strictest": "2.0.5",
+    "@types/cross-spawn": "6.0.6",
     "@types/node": "24.5.2",
     "@types/object-hash": "3.0.6",
     "@types/prettier-v1": "npm:@types/prettier@1.19.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "elm-format": "0.8.8",
-    "execa": "^5.1.1",
     "object-hash": "^3.0.0",
     "serialize-error": "^12.0.0",
     "temp-dir": "^2.0.0"
@@ -75,6 +74,6 @@
   },
   "packageManager": "pnpm@10.17.0",
   "engines": {
-    "node": ">=14.16.0"
+    "node": ">=20.19.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,8 @@
     ]
   },
   "dependencies": {
-    "cross-spawn": "7.0.6",
     "elm-format": "0.8.8",
-    "npm-run-path": "4.0.1",
+    "execa": "^5.1.1",
     "object-hash": "^3.0.0",
     "serialize-error": "^12.0.0",
     "temp-dir": "^2.0.0"
@@ -55,7 +54,6 @@
     "@kachkaev/markdownlint-config": "0.5.0",
     "@tsconfig/recommended": "1.0.10",
     "@tsconfig/strictest": "2.0.5",
-    "@types/cross-spawn": "6.0.6",
     "@types/node": "24.5.2",
     "@types/object-hash": "3.0.6",
     "@types/prettier-v1": "npm:@types/prettier@1.19.1",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,8 @@
   "dependencies": {
     "elm-format": "0.8.8",
     "execa": "^5.1.1",
-    "make-dir": "^3.1.0",
     "object-hash": "^3.0.0",
-    "serialize-error": "^8.1.0",
+    "serialize-error": "^12.0.0",
     "temp-dir": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   },
   "packageManager": "pnpm@10.17.0",
   "engines": {
-    "node": ">=20.19.4"
+    "node": ">=18.20.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "cross-spawn": "7.0.6",
     "elm-format": "0.8.8",
+    "npm-run-path": "4.0.1",
     "object-hash": "^3.0.0",
     "serialize-error": "^12.0.0",
     "temp-dir": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       elm-format:
         specifier: 0.8.8
         version: 0.8.8
+      npm-run-path:
+        specifier: 4.0.1
+        version: 4.0.1
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
@@ -6349,7 +6352,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-    optional: true
 
   object-hash@3.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,12 @@ importers:
       execa:
         specifier: ^5.1.1
         version: 5.1.1
-      make-dir:
-        specifier: ^3.1.0
-        version: 3.1.0
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
       serialize-error:
-        specifier: ^8.1.0
-        version: 8.1.0
+        specifier: ^12.0.0
+        version: 12.0.0
       temp-dir:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2316,10 +2313,6 @@ packages:
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -2825,9 +2818,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-error@8.1.0:
-    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
-    engines: {node: '>=10'}
+  serialize-error@12.0.0:
+    resolution: {integrity: sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==}
+    engines: {node: '>=18'}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -3107,6 +3100,10 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -6035,10 +6032,6 @@ snapshots:
       '@babel/types': 7.28.4
       source-map-js: 1.2.1
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
-
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.2
@@ -6677,9 +6670,9 @@ snapshots:
 
   semver@7.7.2: {}
 
-  serialize-error@8.1.0:
+  serialize-error@12.0.0:
     dependencies:
-      type-fest: 0.20.2
+      type-fest: 4.41.0
 
   set-function-length@1.2.2:
     dependencies:
@@ -6975,6 +6968,8 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
+
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      cross-spawn:
+        specifier: 7.0.6
+        version: 7.0.6
       elm-format:
         specifier: 0.8.8
         version: 0.8.8
@@ -33,6 +36,9 @@ importers:
       '@tsconfig/strictest':
         specifier: 2.0.5
         version: 2.0.5
+      '@types/cross-spawn':
+        specifier: 6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: 24.5.2
         version: 24.5.2
@@ -786,6 +792,9 @@ packages:
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4107,6 +4116,10 @@ snapshots:
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 24.5.2
 
   '@types/debug@4.1.12':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,12 @@ importers:
 
   .:
     dependencies:
-      cross-spawn:
-        specifier: 7.0.6
-        version: 7.0.6
       elm-format:
         specifier: 0.8.8
         version: 0.8.8
-      npm-run-path:
-        specifier: 4.0.1
-        version: 4.0.1
+      execa:
+        specifier: ^5.1.1
+        version: 5.1.1
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
@@ -39,9 +36,6 @@ importers:
       '@tsconfig/strictest':
         specifier: 2.0.5
         version: 2.0.5
-      '@types/cross-spawn':
-        specifier: 6.0.6
-        version: 6.0.6
       '@types/node':
         specifier: 24.5.2
         version: 24.5.2
@@ -795,9 +789,6 @@ packages:
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
-
-  '@types/cross-spawn@6.0.6':
-    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4120,10 +4111,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
-  '@types/cross-spawn@6.0.6':
-    dependencies:
-      '@types/node': 24.5.2
-
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -5135,7 +5122,6 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    optional: true
 
   exit-x@0.2.2:
     optional: true
@@ -5261,8 +5247,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@6.0.1:
-    optional: true
+  get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -5358,8 +5343,7 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  human-signals@2.1.0:
-    optional: true
+  human-signals@2.1.0: {}
 
   husky@9.1.7: {}
 
@@ -5508,8 +5492,7 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-stream@2.0.1:
-    optional: true
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -6102,8 +6085,7 @@ snapshots:
 
   memorystream@0.3.1: {}
 
-  merge-stream@2.0.0:
-    optional: true
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -6284,8 +6266,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mimic-fn@2.1.0:
-    optional: true
+  mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -6395,7 +6376,6 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-    optional: true
 
   onetime@7.0.0:
     dependencies:
@@ -6754,8 +6734,7 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7:
-    optional: true
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -6891,8 +6870,7 @@ snapshots:
   strip-bom@4.0.0:
     optional: true
 
-  strip-final-newline@2.0.0:
-    optional: true
+  strip-final-newline@2.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       elm-format:
         specifier: 0.8.8
         version: 0.8.8
-      execa:
-        specifier: ^5.1.1
-        version: 5.1.1
       object-hash:
         specifier: ^3.0.0
         version: 3.0.0
@@ -5122,6 +5119,7 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+    optional: true
 
   exit-x@0.2.2:
     optional: true
@@ -5247,7 +5245,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@6.0.1: {}
+  get-stream@6.0.1:
+    optional: true
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -5343,7 +5342,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  human-signals@2.1.0: {}
+  human-signals@2.1.0:
+    optional: true
 
   husky@9.1.7: {}
 
@@ -5492,7 +5492,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
-  is-stream@2.0.1: {}
+  is-stream@2.0.1:
+    optional: true
 
   is-string@1.1.1:
     dependencies:
@@ -6085,7 +6086,8 @@ snapshots:
 
   memorystream@0.3.1: {}
 
-  merge-stream@2.0.0: {}
+  merge-stream@2.0.0:
+    optional: true
 
   merge2@1.4.1: {}
 
@@ -6266,7 +6268,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  mimic-fn@2.1.0: {}
+  mimic-fn@2.1.0:
+    optional: true
 
   mimic-function@5.0.1: {}
 
@@ -6333,6 +6336,7 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+    optional: true
 
   object-hash@3.0.0: {}
 
@@ -6376,6 +6380,7 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+    optional: true
 
   onetime@7.0.0:
     dependencies:
@@ -6734,7 +6739,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7: {}
+  signal-exit@3.0.7:
+    optional: true
 
   signal-exit@4.1.0: {}
 
@@ -6870,7 +6876,8 @@ snapshots:
   strip-bom@4.0.0:
     optional: true
 
-  strip-final-newline@2.0.0: {}
+  strip-final-newline@2.0.0:
+    optional: true
 
   strip-indent@3.0.0:
     dependencies:

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import makeDir from "make-dir";
 import objectHash from "object-hash";
 import path from "path";
 import type { ErrorObject } from "serialize-error";
@@ -108,7 +107,7 @@ export const getCachedValue = <Args extends any[], Result>(
   }
 
   try {
-    makeDir.sync(cacheDir);
+    fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(`${recordFilePath}.touchfile`, "");
     if (!recordIsFromCache) {
       fs.writeFileSync(recordFilePath, JSON.stringify(record), "utf8");

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -99,7 +99,7 @@ export const getCachedValue = <Args extends any[], Result>(
         value: fn(...args),
       };
     } catch (fnError) {
-      const serializedError = serializeError(fnError);
+      const serializedError = serializeError(fnError) as ErrorObject;
       delete serializedError.stack;
       record = {
         error: serializedError,

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,7 @@
-import fs from "fs";
+import fs from "node:fs";
+import path from "node:path";
+
 import objectHash from "object-hash";
-import path from "path";
 import type { ErrorObject } from "serialize-error";
 import { serializeError } from "serialize-error";
 import tempDir from "temp-dir";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,26 @@
-import execa from "execa";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import fs from "node:fs";
+
+const findElmFormat = (): string => {
+  const localElmFormat = resolve(
+    __dirname,
+    "..",
+    "node_modules",
+    ".bin",
+    "elm-format",
+  );
+
+  try {
+    if (fs.existsSync(localElmFormat)) {
+      return localElmFormat;
+    }
+  } catch {
+    // Ignore errors and fall back to global
+  }
+
+  return "elm-format";
+};
 
 let cachedElmFormatVersion: string;
 
@@ -7,24 +29,44 @@ export const getElmFormatVersion = () => {
     // a cleaner way of getting elm-format version
     // will be possible when this issue is closed:
     // https://github.com/avh4/elm-format/issues/425
-    const help = execa.sync("elm-format", ["--help"], {
-      preferLocal: true,
-      localDir: __dirname,
+    const elmFormatPath = findElmFormat();
+    const result = spawnSync(elmFormatPath, ["--help"], {
+      cwd: __dirname,
       timeout: 5000,
-    }).stdout;
-    const helpMatch = help.match(/elm-format ([^\n]+)/);
-    cachedElmFormatVersion = helpMatch?.[1] ?? "unknown";
+      encoding: "utf8",
+    });
+
+    if (result.error) {
+      cachedElmFormatVersion = "unknown";
+    } else {
+      const help = result.stdout || "";
+      const helpMatch = help.match(/elm-format ([^\n]+)/);
+      cachedElmFormatVersion = helpMatch?.[1] ?? "unknown";
+    }
   }
 
   return cachedElmFormatVersion;
 };
 
 export const formatTextWithElmFormat = (text: string): string => {
-  return execa.sync("elm-format", ["--stdin", "--elm-version=0.19"], {
+  const elmFormatPath = findElmFormat();
+  const result = spawnSync(elmFormatPath, ["--stdin", "--elm-version=0.19"], {
     input: text,
-    preferLocal: true,
-    localDir: __dirname,
-    stripFinalNewline: false,
+    cwd: __dirname,
     timeout: 15_000,
-  }).stdout;
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to format Elm code: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const errorOutput = result.stderr || "";
+    throw new Error(
+      `elm-format failed with exit code ${result.status}: ${errorOutput}`,
+    );
+  }
+
+  return result.stdout || "";
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,7 @@
-import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
 import fs from "node:fs";
+import { resolve } from "node:path";
+
+import { sync as spawnSync } from "cross-spawn";
 
 const findElmFormat = (): string => {
   const localElmFormat = resolve(
@@ -64,7 +65,7 @@ export const formatTextWithElmFormat = (text: string): string => {
   if (result.status !== 0) {
     const errorOutput = result.stderr || "";
     throw new Error(
-      `elm-format failed with exit code ${result.status}: ${errorOutput}`,
+      `elm-format failed with exit code ${result.status ?? "null"}: ${errorOutput}`,
     );
   }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,27 +1,6 @@
 import fs from "node:fs";
-import { resolve } from "node:path";
-
+import npmRunPath from "npm-run-path";
 import { sync as spawnSync } from "cross-spawn";
-
-const findElmFormat = (): string => {
-  const localElmFormat = resolve(
-    __dirname,
-    "..",
-    "node_modules",
-    ".bin",
-    "elm-format",
-  );
-
-  try {
-    if (fs.existsSync(localElmFormat)) {
-      return localElmFormat;
-    }
-  } catch {
-    // Ignore errors and fall back to global
-  }
-
-  return "elm-format";
-};
 
 let cachedElmFormatVersion: string;
 
@@ -30,11 +9,11 @@ export const getElmFormatVersion = () => {
     // a cleaner way of getting elm-format version
     // will be possible when this issue is closed:
     // https://github.com/avh4/elm-format/issues/425
-    const elmFormatPath = findElmFormat();
-    const result = spawnSync(elmFormatPath, ["--help"], {
+    const result = spawnSync("elm-format", ["--help"], {
       cwd: __dirname,
-      timeout: 5000,
       encoding: "utf8",
+      env: npmRunPath.env({ cwd: __dirname }),
+      timeout: 5000,
     });
 
     if (result.error) {
@@ -50,12 +29,12 @@ export const getElmFormatVersion = () => {
 };
 
 export const formatTextWithElmFormat = (text: string): string => {
-  const elmFormatPath = findElmFormat();
-  const result = spawnSync(elmFormatPath, ["--stdin", "--elm-version=0.19"], {
-    input: text,
+  const result = spawnSync("elm-format", ["--stdin", "--elm-version=0.19"], {
     cwd: __dirname,
-    timeout: 15_000,
     encoding: "utf8",
+    env: npmRunPath.env({ cwd: __dirname }),
+    input: text,
+    timeout: 15_000,
   });
 
   if (result.error) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,4 @@
-import fs from "node:fs";
-import npmRunPath from "npm-run-path";
-import { sync as spawnSync } from "cross-spawn";
+import execa from "execa";
 
 let cachedElmFormatVersion: string;
 
@@ -9,44 +7,24 @@ export const getElmFormatVersion = () => {
     // a cleaner way of getting elm-format version
     // will be possible when this issue is closed:
     // https://github.com/avh4/elm-format/issues/425
-    const result = spawnSync("elm-format", ["--help"], {
-      cwd: __dirname,
-      encoding: "utf8",
-      env: npmRunPath.env({ cwd: __dirname }),
+    const help = execa.sync("elm-format", ["--help"], {
+      preferLocal: true,
+      localDir: __dirname,
       timeout: 5000,
-    });
-
-    if (result.error) {
-      cachedElmFormatVersion = "unknown";
-    } else {
-      const help = result.stdout || "";
-      const helpMatch = help.match(/elm-format ([^\n]+)/);
-      cachedElmFormatVersion = helpMatch?.[1] ?? "unknown";
-    }
+    }).stdout;
+    const helpMatch = help.match(/elm-format ([^\n]+)/);
+    cachedElmFormatVersion = helpMatch?.[1] ?? "unknown";
   }
 
   return cachedElmFormatVersion;
 };
 
 export const formatTextWithElmFormat = (text: string): string => {
-  const result = spawnSync("elm-format", ["--stdin", "--elm-version=0.19"], {
-    cwd: __dirname,
-    encoding: "utf8",
-    env: npmRunPath.env({ cwd: __dirname }),
+  return execa.sync("elm-format", ["--stdin", "--elm-version=0.19"], {
     input: text,
+    preferLocal: true,
+    localDir: __dirname,
+    stripFinalNewline: false,
     timeout: 15_000,
-  });
-
-  if (result.error) {
-    throw new Error(`Failed to format Elm code: ${result.error.message}`);
-  }
-
-  if (result.status !== 0) {
-    const errorOutput = result.stderr || "";
-    throw new Error(
-      `elm-format failed with exit code ${result.status ?? "null"}: ${errorOutput}`,
-    );
-  }
-
-  return result.stdout || "";
+  }).stdout;
 };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
+    "noCheck": true,
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
Now supporting Node 18+ only
- Node 18 reached end of life in April 2025, but all dependencies can still work with it
- Node 16 reached end of life in September 2023
- Node 14 reached end of life in April 2023

See https://github.com/nodejs/Release for Node.js release schedules